### PR TITLE
fix(IniSection): deprecated message because of nullable parent

### DIFF
--- a/src/IniSection.php
+++ b/src/IniSection.php
@@ -27,7 +27,7 @@ class IniSection
      * @param string $name
      * @param IniSection|null $parent
      */
-    public function __construct($name, IniSection $parent = null)
+    public function __construct($name, ?IniSection $parent = null)
     {
         $this->name = $name;
         $this->parent = $parent;


### PR DESCRIPTION
I'm using PHP 8.4, but when I create a new instance of IniSection (for example `$section = new IniSection('base');`), I'm getting the following deprecated message:

> Deprecated: Retrinko\Ini\IniSection::__construct(): Implicitly marking parameter $parent as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/citool/vendor/retrinko/ini/src/IniSection.php on line 30

This is because in https://github.com/retrinko/ini/blob/c0eaa314de962170580c0a44d8f4f91a088e25bd/src/IniSection.php#L30C1-L30C66 the `$parent` is nullable, but the type `IniSection` is not nullable. This pull request adds the missing `?`.